### PR TITLE
Add zeek/zeek-version.h include

### DIFF
--- a/src/ECAT.h
+++ b/src/ECAT.h
@@ -10,6 +10,12 @@
 
 #pragma once
 
+#if __has_include(<zeek/zeek-version.h>)
+#include <zeek/zeek-version.h>
+#else
+#include <zeek/zeek-config.h>
+#endif
+
 #include "zeek/packet_analysis/Analyzer.h"
 #include "zeek/packet_analysis/Component.h"
 #include <sys/socket.h>


### PR DESCRIPTION
Due to zeek/zeek#2806 with the latest master version this requires an explicit `zeek/zeek-version.h` include. That include is good practice anyway.

Reference zeek/zeek#2847.

Originally suggested by @awelzel in cisagov/icsnpp-bacnet#19.