### PR TITLE
change comment format to avoid "discarded extraneous zeekygen comment" warnings

### DIFF
--- a/scripts/consts.zeek
+++ b/scripts/consts.zeek
@@ -1,4 +1,4 @@
-## Copyright (c) 2020 Battelle Energy Alliance, LLC.  All rights reserved.
+##! Copyright (c) 2020 Battelle Energy Alliance, LLC.  All rights reserved.
 module PacketAnalyzer::ECAT;
 
 export{

--- a/scripts/icsnpp/ethercat/main.zeek
+++ b/scripts/icsnpp/ethercat/main.zeek
@@ -1,12 +1,12 @@
-## Copyright (c) 2020 Battelle Energy Alliance, LLC.  All rights reserved."
-## main.zeek
-##
-## Packet Analyzer Ethercat Analyzer - Contains the base script-layer 
-##                                     functionality for processing events 
-##                                     emitted from the analyzer.
-##
-## Author:   Devin Vollmer
-## Contact:  devin.vollmer@inl.gov
+##! Copyright (c) 2020 Battelle Energy Alliance, LLC.  All rights reserved."
+##! main.zeek
+##!
+##! Packet Analyzer Ethercat Analyzer - Contains the base script-layer
+##!                                     functionality for processing events
+##!                                     emitted from the analyzer.
+##!
+##! Author:   Devin Vollmer
+##! Contact:  devin.vollmer@inl.gov
 
 module PacketAnalyzer::ECAT;
 


### PR DESCRIPTION
Changed some double-pound comments to double-pound-bash comments to avoid 'discarded extraneous zeekygen comment' warning, see [zeekygen/example.zeek](https://github.com/zeek/zeek/blob/master/scripts/zeekygen/example.zeek) for reference.

Every time I run zeek with this script installed, we see something like this warning:

```
warning in ..., line 1: Discarded extraneous Zeekygen comment: profinet_io_processing.zeek
warning in ..., line 1: Discarded extraneous Zeekygen comment: 
warning in ..., line 1: Discarded extraneous Zeekygen comment: Zeek Processing. Matches the Types from Spicy (exported .evt) to zeek (types.zeek)
warning in ..., line 1: Discarded extraneous Zeekygen comment: 
warning in ..., line 1: Discarded extraneous Zeekygen comment: 
warning in ..., line 1: Discarded extraneous Zeekygen comment: Author:   Taegan Williams
warning in ..., line 1: Discarded extraneous Zeekygen comment: Contact:  taegan.williams@inl.gov
warning in ..., line 1: Discarded extraneous Zeekygen comment: 
warning in ..., line 1: Discarded extraneous Zeekygen comment: Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
```

If you read the file I linked, it talks about the difference between `#`, `##`, and `##!` comments.

This commit changes the `##` comments at the beginning of the file to `##!` comments.